### PR TITLE
add custom domain for ui

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,6 +1,6 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
-const PROJECT_NAME = "react-monorepo-template";
+const PROJECT_NAME = "test-subdomain";
 const CUSTOMER = "wakeuplabs";
 
 export default $config({
@@ -25,10 +25,48 @@ export default $config({
       url: true
     });
 
-    const ui = new sst.StaticSite(`${PROJECT_NAME}-ui`, {
+    /**
+     * Example: Setting up Custom Domains with SST
+     * 
+     * Below is an example of how to configure custom domains for different AWS services:
+     * 
+     * 1. ECS Service with API Gateway:
+     * - Creates an ECS service with service discovery
+     * - Exposes it through API Gateway with a custom domain
+     * - Useful for containerized applications that need a custom domain
+     * 
+     * You can use this as a reference and modify/remove as needed.
+     * @see https://sst.dev/docs/component/aws/service
+     */
+    // const service = new sst.aws.Service("MyService", {
+    //   cluster,
+    // Configure service discovery for ECS
+    //   serviceRegistry: {
+    //     port: 80
+    //   }
+    // });
+    
+    // Set up API Gateway with custom domain
+    // const apiGateway = new sst.aws.ApiGatewayV2("MyApi", {
+    //   domain: {
+    //     // Example: Using stage in domain name for different environments
+    //     name: `${$app.stage}-${PROJECT_NAME}-api.wakeuplabs.link`,
+    //     // Optional: You can also specify hostedZone if domain is in Route53
+    //     // hostedZone: "your-domain.com"
+    //   },
+    // });
+    // Route all traffic to the ECS service
+    // apiGateway.routePrivate("$default", service.nodes.cloudmapService.arn);
+
+    const ui = new sst.aws.StaticSite(`${PROJECT_NAME}-ui`, {
       path: "packages/ui",
-      buildCommand: "npm run build",
-      buildOutput: "dist",
+      domain: {
+        name: `${$app.stage}-${PROJECT_NAME}.wakeuplabs.link`,
+      },
+      build: {
+        command: "npm run build",
+        output: "dist",
+      },
       environment: {
         VITE_API_URL: api.url,
       },

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,6 +1,6 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
-const PROJECT_NAME = "test-subdomain";
+const PROJECT_NAME = "react-monorepo-template";
 const CUSTOMER = "wakeuplabs";
 
 export default $config({


### PR DESCRIPTION
## Ticket / Issue Tracking
[MT-3](https://wakeuplabs.atlassian.net/browse/MT-3)

## Description
This PR updates the SST configuration to support custom domains and modernizes the StaticSite configuration syntax. Key changes include:

- Updated StaticSite configuration to use the new `sst.aws.StaticSite` syntax
- Added custom domain support for the UI using the pattern `{stage}-{projectName}.wakeuplabs.link`
- Added example configuration for ECS Service with API Gateway (commented out for reference)

